### PR TITLE
fix rollout behaviour

### DIFF
--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -80,7 +80,7 @@ func (h *Handler) Run(v HPAView) (*int32, error) {
 	}
 
 	oldMinReplicas := v.MinReplicas()
-	newMinReplicas := max(v.CurrentReplicas()-1, *lrl)
+	newMinReplicas := max(v.DesiredReplicas()-1, *lrl)
 
 	if newMinReplicas == oldMinReplicas {
 		logger.Debug("(nothingtodohere)")

--- a/cmd/handler_test.go
+++ b/cmd/handler_test.go
@@ -32,49 +32,49 @@ func TestHandleValidCases(t *testing.T) {
 		name            string
 		offset          time.Duration
 		lowerLimit      int32
-		currentReplicas int32
+		desiredReplicas int32
 		expect          int32
 	}{
 		{
 			name:            "WithinCooldown",
 			offset:          3 * time.Minute,
 			lowerLimit:      6,
-			currentReplicas: 11,
+			desiredReplicas: 11,
 			expect:          10,
 		},
 		{
 			name:            "AfterCooldown",
 			offset:          10 * time.Minute,
 			lowerLimit:      6,
-			currentReplicas: 11,
+			desiredReplicas: 11,
 			expect:          10,
 		},
 		{
 			name:            "NoActionLowerLimit",
 			offset:          10 * time.Minute,
 			lowerLimit:      11,
-			currentReplicas: 11,
+			desiredReplicas: 11,
 			expect:          11,
 		},
 		{
 			name:            "EnforceLowerLimit",
 			offset:          10 * time.Minute,
 			lowerLimit:      12,
-			currentReplicas: 11,
+			desiredReplicas: 11,
 			expect:          12,
 		},
 		{
 			name:            "ScaleUpWithinCooldown",
 			offset:          2 * time.Minute,
 			lowerLimit:      12,
-			currentReplicas: 20,
+			desiredReplicas: 20,
 			expect:          19,
 		},
 		{
 			name:            "ScaleUpAfterCooldown",
 			offset:          10 * time.Minute,
 			lowerLimit:      12,
-			currentReplicas: 20,
+			desiredReplicas: 20,
 			expect:          19,
 		},
 	}
@@ -82,7 +82,7 @@ func TestHandleValidCases(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			hpa := testCreateHPA()
-			hpa.Status.CurrentReplicas = tc.currentReplicas
+			hpa.Status.DesiredReplicas = tc.desiredReplicas
 			hpa.ObjectMeta.Annotations["rebuy.com/kubernetes-hpaa.lower-replica-limit"] = fmt.Sprint(tc.lowerLimit)
 			hpa.ObjectMeta.Annotations["rebuy.com/kubernetes-hpaa.downscale-cooldown"] = "5m"
 			v := HPAView(*hpa)

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -25,7 +25,7 @@ func (v HPAView) Logger() *log.Entry {
 		".spec.minReplicas":       v.MinReplicas(),
 		".spec.maxReplicas":       v.Spec.MaxReplicas,
 		".status.lastScaleTime":   v.Status.LastScaleTime,
-		".status.currentReplicas": v.Status.CurrentReplicas,
+		".status.desiredReplicas": v.Status.DesiredReplicas,
 		"#lastChange":             v.LastChange(),
 		"#lowerReplicaLimit":      v.LowerReplicaLimit(),
 		"#downscaleCooldown":      v.DownscaleCooldown(),
@@ -94,6 +94,6 @@ func (v HPAView) MinReplicas() int32 {
 	return *v.Spec.MinReplicas
 }
 
-func (v HPAView) CurrentReplicas() int32 {
-	return v.Status.CurrentReplicas
+func (v HPAView) DesiredReplicas() int32 {
+	return v.Status.DesiredReplicas
 }


### PR DESCRIPTION
We need to use `desiredReplicas` instead of `currentReplicas`. Otherwise the HPAA goes crazy on rollouts with `maxSurge` > 0.

@rebuy-de/prp-kubernetes-hpaa Please review.
/cc @omares @RebeccaKoenig 